### PR TITLE
Fix organisation cancellation query

### DIFF
--- a/backend/src/main/java/com/backend/app/repository/OrganisationRepository.java
+++ b/backend/src/main/java/com/backend/app/repository/OrganisationRepository.java
@@ -18,8 +18,8 @@ public interface OrganisationRepository extends JpaRepository<Organisation, Long
     Integer countAllByIdIn(Set<Long> ids);
 
 
-    @Query("select o.id from Organisation o where o.id not in (?1) and o.subscriptionStatus is not null and o.subscriptionStatus <> 'CANCELED'")
-    List<Long> findAllToCancel(List<Long> id);
+    @Query("select o.id from Organisation o where o.id not in :ids and o.subscriptionStatus is not null and o.subscriptionStatus <> 'CANCELED'")
+    List<Long> findAllToCancel(@org.springframework.data.repository.query.Param("ids") List<Long> ids);
 
     @Modifying
     @Query("update Organisation set modificationStatus='DELETED' where id in (?1)")

--- a/backend/src/main/java/com/backend/app/repository/OrganisationRepository.java
+++ b/backend/src/main/java/com/backend/app/repository/OrganisationRepository.java
@@ -18,7 +18,7 @@ public interface OrganisationRepository extends JpaRepository<Organisation, Long
     Integer countAllByIdIn(Set<Long> ids);
 
 
-    @Query("select id from Organisation where id not in (?1) and (subscriptionStatus<>'null' or subscriptionStatus<>'CANCELED')")
+    @Query("select o.id from Organisation o where o.id not in (?1) and o.subscriptionStatus is not null and o.subscriptionStatus <> 'CANCELED'")
     List<Long> findAllToCancel(List<Long> id);
 
     @Modifying

--- a/backend/src/main/java/com/backend/app/repository/OrganisationRepository.java
+++ b/backend/src/main/java/com/backend/app/repository/OrganisationRepository.java
@@ -5,6 +5,7 @@ import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,7 +20,7 @@ public interface OrganisationRepository extends JpaRepository<Organisation, Long
 
 
     @Query("select o.id from Organisation o where o.id not in :ids and o.subscriptionStatus is not null and o.subscriptionStatus <> 'CANCELED'")
-    List<Long> findAllToCancel(@org.springframework.data.repository.query.Param("ids") List<Long> ids);
+    List<Long> findAllToCancel(@Param("ids") List<Long> ids);
 
     @Modifying
     @Query("update Organisation set modificationStatus='DELETED' where id in (?1)")

--- a/backend/src/main/java/com/backend/app/service/WorkTypeValueService.java
+++ b/backend/src/main/java/com/backend/app/service/WorkTypeValueService.java
@@ -60,8 +60,7 @@ public class WorkTypeValueService {
                 worktypeValueFullMapper.updateWorkTypeValueFromDto(wtv,
                         wtvEntity);
                 setWorkTypes(projectId, estimateId, userDetailsImpl, Collections.singletonList(wtv));
-
-                persistWtv(wtvEntity);
+                savedWtv = persistWtv(wtvEntity);
             }
             return savedWtv;
         }).toList();


### PR DESCRIPTION
## Summary
- fix query for detecting organisations that require subscription cancellation

## Testing
- `gradle test` *(fails: Plugin org.springframework.boot not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbda6b9288321abbbe73ad8b1cd1e