### PR TITLE
Refine CSRF handling

### DIFF
--- a/backend/src/main/java/com/backend/auth/security/WebSecurityConfig.java
+++ b/backend/src/main/java/com/backend/auth/security/WebSecurityConfig.java
@@ -25,6 +25,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.HttpStatusReturningLogoutSuccessHandler;
 import org.springframework.security.web.csrf.*;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
@@ -106,8 +107,8 @@ public class WebSecurityConfig {
         http.csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                         .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler())
-                        .requireCsrfProtectionMatcher(request -> !request.getRequestURI().contains("/api/v1/auth/signin") &&
-                                !request.getRequestURI().contains("/api/v1/csrf")));
+                        .ignoringRequestMatchers(new AntPathRequestMatcher("/api/v1/auth/signin"),
+                                new AntPathRequestMatcher("/api/v1/csrf")));
 //        http.csrf(AbstractHttpConfigurer::disable);
         http.sessionManagement(httpSecuritySessionManagementConfigurer ->
                 httpSecuritySessionManagementConfigurer.sessionCreationPolicy


### PR DESCRIPTION
## Summary
- ignore signin and csrf paths using `ignoringRequestMatchers`
- add CSRF tokens only on POST/PUT/PATCH/DELETE requests
- retry failed state-changing requests after refreshing CSRF token
- extract `isStateChanging` helper

## Testing
- `npm run build --prefix frontend`
- `gradle -p backend build`


------
https://chatgpt.com/codex/tasks/task_e_687fd22db67c8321883ec9520b0623e7